### PR TITLE
Generic point clouds support

### DIFF
--- a/miniball.py
+++ b/miniball.py
@@ -45,7 +45,11 @@ def get_circumsphere(S):
     B = numpy.sqrt(numpy.square(U).sum(axis=1))
     U /= B[:, None]
     B /= 2
-    C = numpy.dot(numpy.linalg.solve(numpy.inner(U, U), B), U)
+    A = numpy.inner(U, U)
+    x, *_ = numpy.linalg.lstsq(A, B, rcond=None)
+    if not numpy.isclose(((A @ x - B) ** 2).sum(), 0):
+        raise numpy.linalg.LinAlgError('Linear equation has no solution.')
+    C = numpy.dot(x, U)
     r2 = numpy.square(C).sum()
     C += S[0]
     return C, r2

--- a/miniball.py
+++ b/miniball.py
@@ -23,7 +23,7 @@ import numpy
 
 
 __author__ = "Alexandre Devert <marmakoide@hotmail.fr>"
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def get_circumsphere(S):


### PR DESCRIPTION
As described in issue #6:
The code, version `1.2.0`, assumes that points are in generic position in the following sense:
_If the points are d-dimensional, then every p-sphere in R^d passes through at most p+1 points_

If this is not the case, for example if we have four points in 3D lying on a common circle, then the difference vectors used in get_circumsphere are linearly dependent, and we get LinAlgError from numpy.linalg.solve.

There is a good use-case for non-generic point clouds: you can restrict the center of the minimized bounding ball to an affine space by reflecting the points through that affine space. For this reason, it would be useful if the code allowed for such point clouds.

Suggested solution:
Replace `numpy.linalg.solve` by `numpy.linalg.lstsq`.

The linear equation solved is of the form $U^T U x = b$, where we then care about $c = U x$. Therefore, if there is more solutions, it does not matter which one we take: if $x' = x + k$ is a different solution with $k \in \mathrm{Ker}\ U$, then $U x' = U (x + k) = U x = c$.

To treat the potential breaking case where the equation had no solutions and an approximation was returned, we check that the returned vector is really a solution using `numpy.isclose`.

Tests in `test_miniball.py` run successfully.